### PR TITLE
User type implements node

### DIFF
--- a/app/graphql/types/node_type.rb
+++ b/app/graphql/types/node_type.rb
@@ -1,0 +1,4 @@
+module Types
+  class BaseObject < GraphQL::Schema::Object
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -2,9 +2,10 @@
 
 module Types
   class QueryType < Types::BaseObject
-    field :me, User, null: false, description: "Authenticated user"
+    field :me, User, null: true, description: "Authenticated user"
 
     def me
+      return nil if context[:current_user].is_a? Guest
       context[:current_user]
     end
   end

--- a/app/graphql/types/user.rb
+++ b/app/graphql/types/user.rb
@@ -2,7 +2,8 @@
 
 module Types
   class User < BaseObject
-    field :id, ID, null: true
+    implements GraphQL::Relay::Node.interface
+    field :id, ID, null: false
     field :name, String, null: true
     field :email, String, null: true
   end

--- a/app/graphql/types/user_session.rb
+++ b/app/graphql/types/user_session.rb
@@ -6,13 +6,10 @@ module Types
     field :access_token, String, null: true
     field :user, Types::User, null: true
     field :identity, Types::Identity, null: true
+    delegate :access_token, to: :user, allow_nil: true
 
     def identity
       object
-    end
-
-    def access_token
-      user.access_token
     end
   end
 end

--- a/app/models/guest_identity.rb
+++ b/app/models/guest_identity.rb
@@ -4,7 +4,6 @@ class GuestIdentity
   attr_accessor :identity
 
   def user
-    @user ||= Guest.new
   end
 
   def errors

--- a/features/steps/graphql-steps.js
+++ b/features/steps/graphql-steps.js
@@ -17,6 +17,10 @@ Then('the response is null at {string}', function (loc) {
   return expect(this.lookup(loc)).to.be.null
 })
 
+Then('the response is undefined at {string}', function (loc) {
+  return expect(this.lookup(loc)).to.be.undefined
+})
+
 Then('the response has no errors', function () {
   return expect(this.response.errors).to.be.undefined
 })

--- a/features/steps/registration-steps.js
+++ b/features/steps/registration-steps.js
@@ -29,5 +29,5 @@ Then('the response has a functioning access token at {string}', function (loc) {
 Then('the response does not have a functioning access token at {string}', function (loc) {
   const client = new AppClient({ token: this.lookup(loc) })
 
-  return expect(client.query({ query: gql`query Me { me { id } }` }).then(({ data }) => data.me.id)).to.eventually.be.null
+  return expect(client.query({ query: gql`query Me { me { id } }` }).then(({ data }) => data.me)).to.eventually.be.null
 })

--- a/features/user_authenticates.feature
+++ b/features/user_authenticates.feature
@@ -54,8 +54,7 @@ Feature: User authenticates
     }
     """
     Then the response does not have a functioning access token at "authenticate.accessToken"
-    And the response is null at "authenticate.user.id"
-    And the response is null at "authenticate.user.id"
+    And the response is undefined at "authenticate.user.id"
     And the response has "401" at "authenticate.errors[0].status"
     And the response has "Invalid Credentials" at "authenticate.errors[0].title"
     And the response has "Invalid email or password" at "authenticate.errors[0].detail"


### PR DESCRIPTION
Per
https://gist.github.com/swalkinshaw/3a33e2d292b60e68fcebe12b62bbb3e2#ids-and-the-node-interface,
objects that are persisted ought to have an ID at all times. I'm a bit
hesitant on this because what about cases where we attempt to create an
object, and that object cannot be persisted? Do we merely return null
for the object in those cases?

In any case, this makes the User type a bit more in line with
appropriate graphql api design standards and adjusts the existing things
that return Users to return null in cases the user does not truly exist.

Resolves https://github.com/wecohere/graphql-rails-example/issues/7