### PR TITLE
Expose errors on payloads using the model

### DIFF
--- a/app/graphql/mutations/authenticate.rb
+++ b/app/graphql/mutations/authenticate.rb
@@ -5,7 +5,7 @@ module Mutations
     payload_type Types::UserSession
 
     def resolve(identity:)
-      Identity.authenticate(identity: identity)
+      Identity.authenticate(credentials: identity)
     end
   end
 end

--- a/app/graphql/mutations/register.rb
+++ b/app/graphql/mutations/register.rb
@@ -7,7 +7,7 @@ module Mutations
     payload_type Types::UserSession
 
     def resolve(identity:)
-      Identity.register(identity: identity)
+      Identity.register(credentials: identity)
     end
   end
 end

--- a/app/graphql/types/email_and_password_identity.rb
+++ b/app/graphql/types/email_and_password_identity.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-module Types
-  class EmailAndPasswordIdentityInput < BaseInputObject
-    argument :email, String, required: true
-    argument :password, String, required: true
-  end
-end

--- a/app/graphql/types/payload_object.rb
+++ b/app/graphql/types/payload_object.rb
@@ -3,7 +3,14 @@ module Types
     field :errors, [Error], null: true
 
     def errors
-      object.errors if object.respond_to?(:errors)
+      return nil unless object.respond_to?(:errors)
+      object.errors.map do |field, message|
+        if field == :credentials
+          { status: 401, title: "Invalid Credentials", field: field, detail: message }
+        else
+          { status: 422, title: "Validation Error", field: field, detail: "#{message}" }
+        end
+      end
     end
   end
 end

--- a/app/graphql/types/user_session.rb
+++ b/app/graphql/types/user_session.rb
@@ -5,11 +5,7 @@ module Types
   class UserSession < PayloadObject
     field :access_token, String, null: true
     field :user, Types::User, null: true
-    field :identity, Types::Identity, null: true
     delegate :access_token, to: :user, allow_nil: true
 
-    def identity
-      object
-    end
   end
 end

--- a/app/models/email_and_password_identity.rb
+++ b/app/models/email_and_password_identity.rb
@@ -8,8 +8,18 @@ class EmailAndPasswordIdentity < Identity
     record.errors.add(:password, :blank) unless record.password_digest.present?
   end
 
+  def self.register(credentials)
+    identity = EmailAndPasswordIdentity.new(identifier: credentials.email_and_password.email,
+                                            password: credentials.email_and_password.password, user: User.new)
+    return GuestIdentity.new(identity: identity) unless identity.valid?
+    identity.save
+    identity
+  end
+
   def self.authenticate(identity)
-    find_by(identifier: identity.email_and_password.email)
-      &.authenticate(identity.email_and_password.password)
+    record = find_by(identifier: identity.email_and_password.email)
+    return record if record.authenticate(identity.email_and_password.password)
+    record.errors.add(:credentials, "Invalid email or password")
+    GuestIdentity.new(identity: record)
   end
 end

--- a/app/models/guest_identity.rb
+++ b/app/models/guest_identity.rb
@@ -4,16 +4,10 @@ class GuestIdentity
   attr_accessor :identity
 
   def user
+    nil
   end
 
   def errors
-    [
-      { status: "401", title: "Invalid Credentials", detail: "Invalid email or password" }
-    ]
-  end
-
-  def detail
-    return "Invalid email or password" if identity.email_and_password
-    return "Invalid access token" if identity.access_token
+    identity.errors
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,10 +7,10 @@ class User < ApplicationRecord
   has_many :email_and_password_identities, class_name: :EmailAndPasswordIdentity
 
   def access_token
-    access_token_identities.first.identifier
+    access_token_identities&.first&.identifier
   end
 
   def email
-    email_and_password_identities.first.identifier
+    email_and_password_identities&.first&.identifier
   end
 end

--- a/features/steps/graphql-steps.js
+++ b/features/steps/graphql-steps.js
@@ -21,10 +21,14 @@ Then('the response is undefined at {string}', function (loc) {
   return expect(this.lookup(loc)).to.be.undefined
 })
 
-Then('the response has no errors', function () {
+Then('the response has no system level errors', function () {
   return expect(this.response.errors).to.be.undefined
 })
 
 Then('the response has an ID at {string}', function (loc) {
   return expect(this.lookup(loc)).not.to.be.empty
+})
+
+Then('the response is empty at {string}', function (loc) {
+  return expect(this.lookup(loc)).to.be.empty
 })

--- a/features/steps/registration-steps.js
+++ b/features/steps/registration-steps.js
@@ -31,3 +31,9 @@ Then('the response does not have a functioning access token at {string}', functi
 
   return expect(client.query({ query: gql`query Me { me { id } }` }).then(({ data }) => data.me)).to.eventually.be.null
 })
+
+Then('I can authenticate with my email and password via the authenticate mutation', function () {
+  const identity = { emailAndPassword: { email: this.data.me.email, password: this.data.me.password } }
+  return expect(this.client.authenticate({ identity }).then(({ data }) => data.authenticate.access_token))
+    .to.eventually.not.be.null
+})

--- a/features/support/app-client.js
+++ b/features/support/app-client.js
@@ -27,6 +27,12 @@ exports.AppClient = class AppClient {
     this.query = this.client.query.bind(this.client)
   }
 
+  authenticate ({ identity }) {
+    return this.mutate({ variables: { identity },
+      mutation: gql`mutation Authenticate($identity: IdentityInput!) {
+      authenticate(identity: $identity) { accessToken user { id, name } } }` })
+  }
+
   register ({ identity }) {
     return this.mutate({ variables: { identity }, mutation: gql`mutation Register($identity: IdentityInput!) {
       register(identity: $identity) {

--- a/features/user_registers.feature
+++ b/features/user_registers.feature
@@ -3,7 +3,7 @@ Feature: User registers
   As a User
   I would like to be able to register an account
 
-  Scenario: Username and password registration
+  Scenario: Email and password registration
     Given I have not yet registered
     And the following variables
     """
@@ -22,16 +22,44 @@ Feature: User registers
           id
           email
         }
-        identity {
-          identifier
-          type
-        }
+        errors { status, title, detail }
       }
     }
     """
-    Then the response has no errors
+    Then the response has no system level errors
+    Then the response is empty at "register.errors"
     And the response has an ID at "register.user.id"
     And the response has a functioning access token at "register.accessToken"
-    And the response has "{{ me.email }}" at "register.identity.identifier"
-    And the response has "EmailAndPasswordIdentity" at "register.identity.type"
+    And I can authenticate with my email and password via the authenticate mutation
+
+
+  Scenario: Email already taken
+    Given I have already registered
+    And the following variables
+    """
+    {
+      "identity": {
+        "emailAndPassword": { "email": "{{ me.email }}", "password": "{{ me.password }}" }
+      }
+    }
+    """
+    When I run the following mutation
+    """
+    mutation Register($identity: IdentityInput!) {
+      register(identity: $identity) {
+        accessToken
+        user {
+          id
+          email
+        }
+        errors { status, title, detail }
+      }
+    }
+    """
+    Then the response has no system level errors
+    And the response is null at "register.user"
+    And the response is null at "register.accessToken"
+    And the response has "has already been taken" at "register.errors[0].detail"
+    And the response has "422" at "register.errors[0].status"
+    And the response has "Validation Error" at "register.errors[0].title"
 


### PR DESCRIPTION
I stubbed out error generation initially, but wanted to make it a bit
more robust. Now we bubble active record errors out a bit more
effectively. I'm trying to figure out how to do "location" level things,
given there's a strong disconnect between InputObjects and ActiveRecord
fields, so I'm punting that for now.

Resolves https://github.com/wecohere/graphql-rails-example/issues/4
Resolves https://github.com/wecohere/graphql-rails-example/issues/6