### PR TITLE
User may retrieve their tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ ruby "2.5.1"
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem "rails", "~> 5.2.0"
 # Use sqlite3 as the database for Active Record
-gem "sqlite3"
+gem "pg"
 # Use Puma as the app server
 gem "puma", "~> 3.11"
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,7 @@ GEM
     parallel (1.12.1)
     parser (2.5.1.2)
       ast (~> 2.4.0)
+    pg (1.0.0)
     powerpack (0.1.2)
     pry (0.11.3)
       coderay (~> 1.1.0)
@@ -153,7 +154,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.13)
     thor (0.20.0)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -179,6 +179,7 @@ DEPENDENCIES
   graphql-errors
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
+  pg
   pry
   puma (~> 3.11)
   rails (~> 5.2.0)
@@ -187,7 +188,6 @@ DEPENDENCIES
   rubocop-rspec
   spring
   spring-watcher-listen (~> 2.0.0)
-  sqlite3
   tzinfo-data
   web-console (>= 3.3.0)
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ I would recommend reading through the feature tests that demonstrate the feature
 
 ## Running the example
 
-This is written in ruby 2.5 and the feature tests are relying on node 9+. The database is sqlite for ease of installation purposes.
+This is written in ruby 2.5 and the feature tests are relying on node 9+. The database is postresql.
 
 I recommend running the app on port 5000, using `bin/rails s -p 5000`
 

--- a/app/graphql/types/task.rb
+++ b/app/graphql/types/task.rb
@@ -6,6 +6,6 @@ module Types
     field :title, String, null: true
     field :description, String, null: true
 
-    field :task_lists, [TaskList], null: true
+    field :task_lists, TaskList.connection_type, null: true
   end
 end

--- a/app/graphql/types/task_list.rb
+++ b/app/graphql/types/task_list.rb
@@ -3,7 +3,7 @@ module Types
     implements GraphQL::Relay::Node.interface
     field :id, ID, null: false
     field :name, String, null: true
-    field :owners, [User], null: true
-    field :tasks, [Task], null: true
+    field :owners, User.connection_type, null: true
+    field :tasks, Task.connection_type, null: true
   end
 end

--- a/app/graphql/types/user.rb
+++ b/app/graphql/types/user.rb
@@ -6,5 +6,7 @@ module Types
     field :id, ID, null: false
     field :name, String, null: true
     field :email, String, null: true
+
+    field :tasks, Task.connection_type, null: true
   end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,25 +1,85 @@
-# SQLite version 3.x
-#   gem install sqlite3
+# PostgreSQL. Versions 9.1 and up are supported.
 #
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
+# Install the pg driver:
+#   gem install pg
+# On OS X with Homebrew:
+#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
+# On OS X with MacPorts:
+#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
+# On Windows:
+#   gem install pg
+#       Choose the win32 build.
+#       Install PostgreSQL and put its /bin directory on your path.
+#
+# Configure Using Gemfile
+# gem 'pg'
 #
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
+  encoding: unicode
+  # For details on connection pooling, see Rails configuration guide
+  # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: rails_graphql_example_development
+
+  # The specified database role being used to connect to postgres.
+  # To create additional roles in postgres see `$ createuser --help`.
+  # When left blank, postgres will use the default role. This is
+  # the same name as the operating system user that initialized the database.
+  #username: rails_graphql_example
+
+  # The password associated with the postgres role (username).
+  #password:
+
+  # Connect on a TCP socket. Omitted by default since the client uses a
+  # domain socket that doesn't need configuration. Windows does not have
+  # domain sockets, so uncomment these lines.
+  #host: localhost
+
+  # The TCP port the server listens on. Defaults to 5432.
+  # If your server runs on a different port number, change accordingly.
+  #port: 5432
+
+  # Schema search path. The server defaults to $user,public
+  #schema_search_path: myapp,sharedapp,public
+
+  # Minimum log levels, in increasing order:
+  #   debug5, debug4, debug3, debug2, debug1,
+  #   log, notice, warning, error, fatal, and panic
+  # Defaults to warning.
+  #min_messages: notice
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: rails_graphql_example_test
 
+# As with config/secrets.yml, you never want to store sensitive information,
+# like your database password, in your source code. If your source code is
+# ever seen by anyone, they now have access to your database.
+#
+# Instead, provide the password as a unix environment variable when you boot
+# the app. Read http://guides.rubyonrails.org/configuring.html#configuring-a-database
+# for a full rundown on how to provide these environment variables in a
+# production deployment.
+#
+# On Heroku and other platform providers, you may have a full connection URL
+# available as an environment variable. For example:
+#
+#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
+#
+# You can use this database configuration with:
+#
+#   production:
+#     url: <%= ENV['DATABASE_URL'] %>
+#
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: rails_graphql_example_production
+  username: rails_graphql_example
+  password: <%= ENV['MEDQUE_DATABASE_PASSWORD'] %>

--- a/features/steps/graphql-steps.js
+++ b/features/steps/graphql-steps.js
@@ -9,8 +9,20 @@ When('I run the following mutation', function (graphql) {
   return this.mutate(graphql)
 })
 
+When('I run the following query', function (graphql) {
+  return this.query(graphql)
+})
+
 Then('the response has {string} at {string}', function (data, loc) {
   return expect(this.lookup(loc)).to.equal(this.interpolate(data))
+})
+
+Then('the response has {int} items at {string}', function (count, loc) {
+  return expect(this.lookup(loc).length).to.equal(count)
+})
+
+Then('the response is true at {string}', function (loc) {
+  return expect(this.lookup(loc)).to.be.true
 })
 
 Then('the response is null at {string}', function (loc) {

--- a/features/steps/steps.js
+++ b/features/steps/steps.js
@@ -5,6 +5,7 @@ const chai = require('chai')
 const chaiAsPromised = require('chai-as-promised')
 
 const { expect } = chai
+const { last, times } = require('lodash')
 
 chai.use(chaiAsPromised)
 
@@ -19,6 +20,16 @@ Given('I have already registered', function () {
 Given('I have a task list', function () {
   return this.client.createTaskList({ name: 'groceries' })
     .then(({ data }) => this.data.me.taskLists.push(data.taskListCreate.taskList))
+})
+
+Given('I have {int} tasks assigned to that task list', function (count) {
+  return Promise.all(times(count, (n) => {
+    const task = { title: `task ${n}` }
+    const taskLists = [last(this.data.me.taskLists).id]
+    return this.client.createTask({ task, taskLists }).then(({ data }) => {
+      return this.data.me.tasks.push(data.tasksCreate.task)
+    })
+  }))
 })
 
 Given('I am making requests as an authenticated member', function () {

--- a/features/support/app-client.js
+++ b/features/support/app-client.js
@@ -43,6 +43,14 @@ exports.AppClient = class AppClient {
     ` })
   }
 
+  createTask ({ task, taskLists }) {
+    return this.mutate({ variables: { task, taskLists },
+      mutation: gql`mutation TasksCreate($task: TaskInput!, $taskLists: [ID!]) {
+        tasksCreate(task: $task, taskLists: $taskLists) {
+          task { id, title, description } }
+      }` })
+  }
+
   createTaskList (taskList) {
     return this.mutate({ variables: { taskList },
       mutation: gql`mutation TaskListCreate($taskList: TaskListInput!) {

--- a/features/support/world.js
+++ b/features/support/world.js
@@ -15,7 +15,7 @@ class World {
   }
 
   randomPerson () {
-    return { email: `user-${cuid()}@example.com`, password: 'password', taskLists: [] }
+    return { email: `user-${cuid()}@example.com`, password: 'password', taskLists: [], tasks: [] }
   }
 
   registerMe () {
@@ -38,7 +38,9 @@ class World {
   }
 
   query (query) {
-    return this.client.query({ query: gql(query), variables: this.variables })
+    return this.client.query({ query: gql(query), variables: this.variables }).then((result) => {
+      this.responses.push(result)
+    })
   }
 
   lookup (loc) {

--- a/features/user_adds_task.feature
+++ b/features/user_adds_task.feature
@@ -25,7 +25,7 @@ Feature: User adds task
           id
           title
           description
-          taskLists { id }
+          taskLists { edges { cursor, node { id } } }
         }
         errors { status, title, detail }
       }
@@ -33,6 +33,6 @@ Feature: User adds task
     """
     Then the response has no system level errors
     And the response is undefined at "taskCreate.errors"
-    And the response has "{{ me.taskLists.0.id }}" at "tasksCreate.task.taskLists[0].id"
+    And the response has "{{ me.taskLists.0.id }}" at "tasksCreate.task.taskLists.edges[0].node.id"
     And the response has "Do a thing!" at "tasksCreate.task.title"
     And the response has "You got to do this! It's so great!" at "tasksCreate.task.description"

--- a/features/user_adds_task_list.feature
+++ b/features/user_adds_task_list.feature
@@ -21,9 +21,9 @@ Feature: User adds task list
       createTaskList(taskList: $taskList) {
         taskList {
           id
-          owners { id }
+          owners { edges { cursor, node { id } } }
           name
-          tasks { id, title, description }
+          tasks { edges { cursor, node { id, title, description } } }
         }
         errors { status, title, detail }
       }
@@ -32,9 +32,9 @@ Feature: User adds task list
     Then the response has no system level errors
     And the response is undefined at "createTasklist.errors"
     And the response has an ID at "createTaskList.taskList.id"
-    And the response is empty at "createTaskList.taskList.tasks"
+    And the response is empty at "createTaskList.taskList.tasks.edges"
     And the response has "groceries" at "createTaskList.taskList.name"
-    And the response has "{{ me.id }}" at "createTaskList.taskList.owners[0].id"
+    And the response has "{{ me.id }}" at "createTaskList.taskList.owners.edges[0].node.id"
 
 
 

--- a/features/user_retrieves_tasks.feature
+++ b/features/user_retrieves_tasks.feature
@@ -1,0 +1,37 @@
+Feature: User retrieves tasks
+  In order to know what I've got to do
+  As a user
+  I would like to be able to list my tasks
+
+
+  Scenario: Retrieving a small set of tasks
+    Given I am making requests as an authenticated member
+    And I have a task list
+    And I have 20 tasks assigned to that task list
+    And the following variables
+    """
+    {
+      "first": 10
+    }
+    """
+    When I run the following query
+    """
+    query Tasks($first: Int) {
+      me {
+        tasks(first: $first) {
+          edges {
+            cursor
+            node { id, title, description }
+          }
+          pageInfo {
+            hasNextPage
+
+          }
+        }
+      }
+    }
+    """
+    Then the response has no system level errors
+    And the response has 10 items at "me.tasks.edges"
+    And the response is true at "me.tasks.pageInfo.hasNextPage"
+


### PR DESCRIPTION
* Refactor to use Relay-style collections, despite being a bit more verbose and abstract. This gives free-ish support for pagination these kind of relations and leans further into the design goals of graphql-ruby
* Switch from sqlite to postgresql, as sqlite3 was running into locking problems when creating many items at once.